### PR TITLE
Fix documentation specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can deprecate a route in any route definition (annotation, yaml, xml, php, w
 - `_deprecated_until` is a `string ("dd-mm-yyyy")` that defines the moment in which a route becomes expired. The header `Sunset` will be set on the response, like so:
   `Sunset: date="Mon, 01 Jun 2020 00:00:00 GMT"`.
   
-- `_enforce_deprecation` is a `boolean` that makes the route inaccessible after the `_deprecated_until` date. If you try to access a route where this option is set to `true` and the current date is greater than the `_deprecated_until` date, a `GoneHttpException` is thrown with Http Status `410 Gone`.
+- `_enforce_deprecation` is a `boolean` that makes the route inaccessible after the `_deprecated_until` date. If you try to access a route where this option is set to `true` and the current date is greater than the `_deprecated_until` date, a `GoneHttpException` is thrown.
 
 You can deprecate a method / endpoint in a controller, or the controller itself (to deprecate all methods / endpoints in the controller).
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ return [
 
 You can deprecate a route in any route definition (annotation, yaml, xml, php, what have you) by passing three values to the `defaults` option:
  
-- `_deprecated_since` is a `string ("dd-mm-yyyy")` that defines the moment in which a route becomes deprecated. If the current date is equal or greater than the value of since, the header `Deprecation` will be set on the response, like so:
+- `_deprecated_since` is a `string ("dd-mm-yyyy")` that defines the moment in which a route becomes deprecated. The header `Deprecation` will be set on the response, like so:
  `Deprecation: date="Wed, 01 Jan 2020 00:00:00 GMT"`.
  
-- `_deprecated_until` is a `string ("dd-mm-yyyy")` that defines the moment in which a route becomes expired. If the current date is equal or greater than the value of until, the header `Sunset` will be set on the response, like so:
+- `_deprecated_until` is a `string ("dd-mm-yyyy")` that defines the moment in which a route becomes expired. The header `Sunset` will be set on the response, like so:
   `Sunset: date="Mon, 01 Jun 2020 00:00:00 GMT"`.
   
-- `_enforce_deprecation` is a `boolean` that makes the route inaccessible after the `_deprecated_until` date. If you try to access a route where this option is set to `true`, a `GoneHttpException` is thrown with HTTP Status 410 Gone.
+- `_enforce_deprecation` is a `boolean` that makes the route inaccessible after the `_deprecated_until` date. If you try to access a route where this option is set to `true` and the current date is greater than the `_deprecated_until` date, a `GoneHttpException` is thrown with Http Status `410 Gone`.
 
 You can deprecate a method / endpoint in a controller, or the controller itself (to deprecate all methods / endpoints in the controller).
 


### PR DESCRIPTION
Fixed oversight in documentation. Closes #11 
- Both headers are set independently of the current date.
- Improved description for `enforce`.