### PR TITLE
Make 'until' optional

### DIFF
--- a/Annotation/DeprecatedRoute.php
+++ b/Annotation/DeprecatedRoute.php
@@ -29,9 +29,8 @@ class DeprecatedRoute extends Route {
 
   /**
    * String date yyyy-MM-dd
-   * @Required
    *
-   * @var string
+   * @var string|null
    */
   private $until;
 
@@ -43,7 +42,7 @@ class DeprecatedRoute extends Route {
   public function __construct(array $data) {
     $this->name = $data['name'];
     $this->since = $data['since'];
-    $this->until = $data['until'];
+    $this->until = $data['until'] ?? null;
 
     unset($data['since']);
     unset($data['until']);


### PR DESCRIPTION
The event subscriber assumes that the `until` option might not be set:

https://github.com/halloverden/symfony-route-deprecation-bundle/blob/36bef50b2cc0b106ddaf75eb208b6ad16e138a5e/EventSubscriber/DeprecatedRouteSubscriber.php#L55-L58

However, the annotation's constructor will cause an `Undefined index: until` error when `until` is omitted:

https://github.com/halloverden/symfony-route-deprecation-bundle/blob/36bef50b2cc0b106ddaf75eb208b6ad16e138a5e/Annotation/DeprecatedRoute.php#L46

This PR fixes that issue.